### PR TITLE
Pull request for #6: Fall 2017 Updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,12 +38,6 @@ Stanford University</p>
 George S. and Nancy B. Parker Professor of Economics<br>
 Brown University</p>
 
-<h6>
-<a id="current-research-professionals" class="anchor" href="#current-research-professionals" aria-hidden="true"><span class="octicon octicon-link"></span></a>Current Research Professionals</h6>
-
-<p><a href="mailto:lboxell@stanford.edu">Levi Boxell</a>, 2015-present<br>
-BA Developmental Economics &amp; Mathematics, Taylor University, 2015</p>
-
 <p><a href="mailto:arosenbe@stanford.edu">Adam Rosenberg</a>, 2016-present<br>
 BA Economics, Middlebury College, 2016</p>
 
@@ -57,16 +51,20 @@ BA Mathematics &amp; Economics, Carleton College, 2017</p>
 <a id="past-members" class="anchor" href="#past-members" aria-hidden="true"><span class="octicon octicon-link"></span></a>Past Members</h3>
 
 <p><a href="https://bepp.wharton.upenn.edu/profile/21190/">Michael Sinkinson</a>, lab member 2006-2007<br>
-Assistant Professor of Business Economics and Public Policy, The Wharton School, University of Pennsylvania, 2012-present<br>
-PhD Business Economics, Harvard University, 2012; B.Com Commerce, Queen’s University, 2004</p>
+Assistant Professor of Economics, Yale School of Management, Yale University, 2017-present<br>
+Assistant Professor of Business Economics and Public Policy, The Wharton School, University of Pennsylvania, 2012-2017<br>
+PhD Business Economics, Harvard University, 2012<br>
+B.Com Commerce, Queen’s University, 2004</p>
 
 <p><a href="https://bepp.wharton.upenn.edu/profile/24541/">Jose Miguel Abito</a>, lab member 2007-2008<br>
 Assistant Professor of Business Economics and Public Policy, The Wharton School, University of Pennsylvania, 2013-present<br>
-PhD Economics, Northwestern University, 2013; MSc Mathematical Economics and Econometrics, Toulouse School of Economics, 2007; B.SocSci. Economics, National University of Singapore, 2006</p>
+PhD Economics, Northwestern University, 2013<br> 
+MSc Mathematical Economics and Econometrics, Toulouse School of Economics, 2007<br> 
+B.SocSci. Economics, National University of Singapore, 2006</p>
 
-<p><a href="http://scholar.harvard.edu/mahon/home">James Mahon</a>, lab member 2007-2009<br>
+<p><a href="https://www.linkedin.com/in/james-f-mahon-iii/">James Mahon</a>, lab member 2007-2009<br>
 Manager, Deloitte Tax, Transfer Pricing Division, 2015-present<br>
-PhD Candidate in Political Economy and Government, Harvard University, 2009-2015<br>
+PhD Political Economy and Government, Harvard University, 2015<br>
 BA Economics &amp; Political Science, Columbia University, 2007</p>
 
 <p><a href="http://www.patdejar.net/">Patrick DeJarnette</a>, lab member 2008-2010<br>
@@ -75,29 +73,35 @@ PhD Applied Economics, The Wharton School, University of Pennsylvania, 2016<br>
 BA Economics &amp; Mathematics, University of Chicago, 2008</p>
 
 <p><a href="http://home.uchicago.edu/~yaolu/index.html">Yao Lu</a>, lab member 2009-2010<br>
-Associate at Analysis Group Boston, starting 2015<br>
-PhD Economics, Booth School of Business, University of Chicago, 2015; BA Economics, Harvard University, 2008</p>
+Associate, Analysis Group Boston, 2015-present<br>
+PhD Economics, Booth School of Business, University of Chicago, 2015<br>
+BA Economics, Harvard University, 2008</p>
 
-<p><a href="mailto:mthomas8@ChicagoBooth.edu">Michael Thomas</a>, lab member 2009-2011<br>
-PhD Candidate in Marketing, Booth School of Business, University of Chicago, 2011-present<br>
-MSc Economics, The London School of Economics and Political Science, 2008;<br> BS Chemical/Biochemical Engineering, University of California, Davis, 1998</p>
+<p><a href="https://www.scu.edu/business/marketing/faculty/thomas/">Michael Thomas</a>, lab member 2009-2011<br>
+Assistant Professor of Marketing, Leavey School of Business, Santa Clara University, 2017-present<br>
+PhD Marketing, Booth School of Business, University of Chicago, 2017<br>
+MSc Economics, The London School of Economics and Political Science, 2008<br>
+BS Chemical/Biochemical Engineering, University of California, Davis, 1998</p>
 
 <p><a href="https://sites.google.com/site/nathanpetek/home">Nathan Petek</a>, lab member 2009-2011<br>
 Economist, Federal Trade Commission, 2016-present<br>
 PhD Economics, Booth School of Business, University of Chicago, 2016<br>
 BA Economics &amp; Psychology, Carleton College, 2004</p>
 
-<p><a href="mailto:verbeck@princeton.edu">CJ Verbeck</a>, lab member 2010-2012<br>
-PhD Candidate in Economics, Princeton University, 2012-present<br>
+<p><a href="http://cverbeck.com/">CJ Verbeck</a>, lab member 2010-2012<br>
+Associate, Analysis Group Los Angeles, 2017-present<br>
+PhD Economics, Princeton University, 2017<br>
 BA Economics &amp; Mathematics, Pomona College, 2010</p>
 
-<p><a href="mailto:liuer@mit.edu">Ernest Liu</a>, lab member 2010-2012<br>
-PhD Candidate in Economics, Massachusetts Institute of Technology, 2012-present<br>
+<p><a href="https://jrc.princeton.edu/people/ernest-liu">Ernest Liu</a>, lab member 2010-2012<br>
+Postdoctoral Research Associate, Woodrow Wilson School, Princeton University, 2017-present<br>
+PhD Economics, Massachusetts Institute of Technology, 2017<br>
 BA Mathematics, Carleton College, 2010</p>
 
 <p><a href="mailto:n.tsivanidis@chicagobooth.edu">Nick Tsivanidis</a>, lab member 2011-2012<br>
 PhD Candidate in Economics, Booth School of Business, University of Chicago, 2012-present<br>
-BS Politics, Philosophy and Economics (Econ Maj), Warwick University, 2009; MA International and Development Economics, Yale University, 2010</p>
+ MA International and Development Economics, Yale University, 2010<br>
+BS Politics, Philosophy and Economics (Econ Maj), Warwick University, 2009</p>
 
 <p><a href="mailto:linhto@fas.harvard.edu">Linh Tô</a>, lab member 2011-2013<br>
 PhD Candidate in Economics, Harvard University, 2013-present<br>
@@ -105,7 +109,8 @@ BA Macalester College, 2007</p>
 
 <p><a href="mailto:chodgson@stanford.edu">Charles Hodgson</a>, lab member 2011-2013<br>
 PhD Candidate in Economics, Stanford University, 2013-present<br>
-MSc Economics, London School of Economics and Political Science, 2011; BS Philosophy &amp; Economics, London School of Economics and Political Science, 2010</p>
+MSc Economics, London School of Economics and Political Science, 2011<br>
+BS Philosophy &amp; Economics, London School of Economics and Political Science, 2010</p>
 
 <p><a href="mailto:Tony.Ditta@chicagobooth.edu">Tony Ditta</a>, lab member 2012-2014<br>
 PhD Candidate in Economics, Booth School of Business, University of Chicago, 2014-present<br>
@@ -135,9 +140,16 @@ BA Economics &amp; Mathematics, Brown University, 2014</p>
 PhD Candidate in Economics, University of Chicago Booth School of Business, 2016-present<br>  
 BA Economics, Brandeis University, 2012</p>
 
+<p><a href="mailto:lboxell@stanford.edu">Levi Boxell</a>, lab member 2015-2017<br>
+PhD Candidate in Economics, Stanford University, 2017-present<br>
+BA Developmental Economics &amp; Mathematics, Taylor University, 2015</p>
+
 <p><a href="mailto:m.r.sullivan@yale.edu"> Michael Sullivan</a>, lab member 2016-2017<br>
 PhD Candidate in Economics, Yale University, 2017-present<br>
 BSc Economics &amp; Pure Mathematics, Memorial University of Newfoundland, 2016</p> 
+
+
+
       </section>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@ PhD Candidate in Economics, Princeton University, 2016-present<br>
 BA Economics &amp; Mathematics, Brown University, 2014</p>
 
 <p><a href="mailto:andres_sha@hotmail.com">Andres Shahidinejad</a>, lab member 2015-2016<br> 
-PhD Candidate in Economics, University of Chicago Booth School of Business, 2016-present<br>  
+PhD Candidate in Economics, Booth School of Business, University of Chicago, 2016-present<br>  
 BA Economics, Brandeis University, 2012</p>
 
 <p><a href="mailto:lboxell@stanford.edu">Levi Boxell</a>, lab member 2015-2017<br>

--- a/index.html
+++ b/index.html
@@ -50,57 +50,56 @@ BA Mathematics &amp; Economics, Carleton College, 2017</p>
 <h3>
 <a id="past-members" class="anchor" href="#past-members" aria-hidden="true"><span class="octicon octicon-link"></span></a>Past Members</h3>
 
-<p><a href="https://bepp.wharton.upenn.edu/profile/21190/">Michael Sinkinson</a>, lab member 2006-2007<br>
-Assistant Professor of Economics, Yale School of Management, Yale University, 2017-present<br>
-Assistant Professor of Business Economics and Public Policy, The Wharton School, University of Pennsylvania, 2012-2017<br>
+<p><a href="http://som.yale.edu/michael-sinkinson">Michael Sinkinson</a>, lab member 2006-2007<br>
+Assistant Professor of Economics, Yale School of Management, Yale University<br>
 PhD Business Economics, Harvard University, 2012<br>
 B.Com Commerce, Queen’s University, 2004</p>
 
 <p><a href="https://bepp.wharton.upenn.edu/profile/24541/">Jose Miguel Abito</a>, lab member 2007-2008<br>
-Assistant Professor of Business Economics and Public Policy, The Wharton School, University of Pennsylvania, 2013-present<br>
+Assistant Professor of Business Economics and Public Policy, The Wharton School, University of Pennsylvania<br>
 PhD Economics, Northwestern University, 2013<br> 
 MSc Mathematical Economics and Econometrics, Toulouse School of Economics, 2007<br> 
 B.SocSci. Economics, National University of Singapore, 2006</p>
 
 <p><a href="https://www.linkedin.com/in/james-f-mahon-iii/">James Mahon</a>, lab member 2007-2009<br>
-Manager, Deloitte Tax, Transfer Pricing Division, 2015-present<br>
+Manager, Deloitte Tax, Transfer Pricing Division<br>
 PhD Political Economy and Government, Harvard University, 2015<br>
 BA Economics &amp; Political Science, Columbia University, 2007</p>
 
 <p><a href="http://www.patdejar.net/">Patrick DeJarnette</a>, lab member 2008-2010<br>
-Assistant Professor of Economics, National Taiwan University, 2016-present<br>
+Assistant Professor of Economics, National Taiwan University<br>
 PhD Applied Economics, The Wharton School, University of Pennsylvania, 2016<br>
 BA Economics &amp; Mathematics, University of Chicago, 2008</p>
 
 <p><a href="http://home.uchicago.edu/~yaolu/index.html">Yao Lu</a>, lab member 2009-2010<br>
-Associate, Analysis Group Boston, 2015-present<br>
+Associate, Analysis Group Boston<br>
 PhD Economics, Booth School of Business, University of Chicago, 2015<br>
 BA Economics, Harvard University, 2008</p>
 
 <p><a href="https://www.scu.edu/business/marketing/faculty/thomas/">Michael Thomas</a>, lab member 2009-2011<br>
-Assistant Professor of Marketing, Leavey School of Business, Santa Clara University, 2017-present<br>
+Assistant Professor of Marketing, Leavey School of Business, Santa Clara University<br>
 PhD Marketing, Booth School of Business, University of Chicago, 2017<br>
 MSc Economics, The London School of Economics and Political Science, 2008<br>
 BS Chemical/Biochemical Engineering, University of California, Davis, 1998</p>
 
 <p><a href="https://sites.google.com/site/nathanpetek/home">Nathan Petek</a>, lab member 2009-2011<br>
-Economist, Federal Trade Commission, 2016-present<br>
+Economist, Federal Trade Commission<br>
 PhD Economics, Booth School of Business, University of Chicago, 2016<br>
 BA Economics &amp; Psychology, Carleton College, 2004</p>
 
 <p><a href="http://cverbeck.com/">CJ Verbeck</a>, lab member 2010-2012<br>
-Associate, Analysis Group Los Angeles, 2017-present<br>
+Associate, Analysis Group Los Angeles<br>
 PhD Economics, Princeton University, 2017<br>
 BA Economics &amp; Mathematics, Pomona College, 2010</p>
 
 <p><a href="https://jrc.princeton.edu/people/ernest-liu">Ernest Liu</a>, lab member 2010-2012<br>
-Postdoctoral Research Associate, Woodrow Wilson School, Princeton University, 2017-present<br>
+Postdoctoral Research Associate, Woodrow Wilson School, Princeton University<br>
 PhD Economics, Massachusetts Institute of Technology, 2017<br>
 BA Mathematics, Carleton College, 2010</p>
 
 <p><a href="mailto:n.tsivanidis@chicagobooth.edu">Nick Tsivanidis</a>, lab member 2011-2012<br>
 PhD Candidate in Economics, Booth School of Business, University of Chicago, 2012-present<br>
- MA International and Development Economics, Yale University, 2010<br>
+MA International and Development Economics, Yale University, 2010<br>
 BS Politics, Philosophy and Economics (Econ Maj), Warwick University, 2009</p>
 
 <p><a href="mailto:linhto@fas.harvard.edu">Linh Tô</a>, lab member 2011-2013<br>


### PR DESCRIPTION
I made updates to the website. 

- Remove "Current research professional headers"

- Mike Sinkinson is now at Yale SOM (congrats!). @jmshapir do you prefer that we list past RAs' first job after grad school, current position, or just everything? 

- Levi is now "PhD Candidate in Economics, Stanford University".

- CJ is now an "Associate, Analysis Group Los Angeles" after graduation from Princeton. (source: [wedding announcement in NYT](https://www.nytimes.com/2017/07/30/fashion/weddings/sardius-chen-channing-verbeck-jr.html))

- Several people's links no longer work, do you want to update to best available? (in many cases, Linkedin)

- Michael Thomas is now at [Santa Clara University](https://www.scu.edu/business/marketing/faculty/thomas/)

- Ernest is now a "Postdoctoral Research Associate, Woodrow Wilson School, Princeton University"

- I cleaned up the formatting. 
